### PR TITLE
Update of FRITZ!Box access

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This an extension for the [MagicMirror](https://github.com/MichMich/MagicMirror)
 ## Installation
 1. Navigate into your MagicMirror's `modules` folder and execute `git clone https://github.com/paviro/MMM-FRITZ-Box-Callmonitor.git`. A new folder will appear navigate into it.
 2. Execute `npm install` to install the dependencies.
-3. Activate the callmonitor of your FRITZ!Box by calling `#96*5*` on a connected phone.
+3. (Optional) Execute `sudo apt-get install python-dev libxml2-dev libxslt1-dev zlib1g-dev && sudo pip install fritzconnection` to allow access to your FRITZ!Box phone book and recent calls. This can take a few minutes.
+4. Activate the callmonitor of your FRITZ!Box by calling `#96*5*` on a connected phone.
 
 ## Using the module
 
@@ -84,6 +85,15 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
+			<td><code>showContactsStatus</code></td>
+			<td>If no recent calls are displayed, a small symbol shows how many contacts are loaded in your phonebook. <br>
+			A small warning sign appears if any error occurs when importing contacts from vCard or the FRITZ!Box.
+			<br>
+				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
+				<br><b>Default value:</b> <code>false</code>
+			</td>
+		</tr>
+		<tr>
 			<td><code>minimumCallLength</code></td>
 			<td>There is no real way to tell whether a call was missed or not because voice mails count as connected calls. You can however change the time a call has to be for it to be considered not missed. You should probably use a value as long as your voice mail. <br>Default <code>0</code> means any call gets added to the history.<br>
 				<br><b>Possible values:</b> <code>time</code> in <code>seconds</code>
@@ -140,7 +150,7 @@ The following properties can be configured:
 - [vcard-json](https://www.npmjs.com/package/vcard-json) (installed by `npm install`)
 - [phone-formatter](https://www.npmjs.com/package/phone-formatter) (installed by `npm install`)
 - [xml2js](https://www.npmjs.com/package/xml2js): (installed by `npm install`)
-- [tr-064](https://www.npmjs.com/package/tr-064): (installed by `npm install`)
+- [fritzconnection](https://pypi.python.org/pypi/fritzconnection): (installed by `sudo apt-get install python-dev libxml2-dev libxslt1-dev zlib1g-dev && sudo pip install fritzconnection`)
 
 The MIT License (MIT)
 =====================

--- a/fritz_access.py
+++ b/fritz_access.py
@@ -1,0 +1,60 @@
+import argparse, os, fritzconnection, urllib2, sys
+
+class FritzAccess(object):
+    """
+    Stores the connection and provide convenience functions
+    """
+
+    def __init__(self, address, port, user, password):
+        super(FritzAccess, self).__init__()
+        self.fc = fritzconnection.FritzConnection(address, port, user, password)
+
+    def download_recent_calls(self, directory):
+        result = self.fc.call_action("X_AVM-DE_OnTel", "GetCallList")
+        filename = os.path.join(directory, "calls.xml")
+        self.download_file(result["NewCallListURL"], filename)
+
+    def download_phone_book(self, directory):
+        result = self.fc.call_action("X_AVM-DE_OnTel", "GetPhonebookList")
+        for phonebook_id in result["NewPhonebookList"]:
+            result_phonebook = self.fc.call_action("X_AVM-DE_OnTel", "GetPhonebook", NewPhonebookID=phonebook_id)
+            filename = os.path.join(directory, "pbook_%s.xml" % phonebook_id)
+            print filename
+            self.download_file(result_phonebook["NewPhonebookURL"], filename)
+
+    def download_file(self, url, filename):
+        try:
+            f = urllib2.urlopen(url)
+            with open(filename, "wb") as local_file:
+                local_file.write(f.read())
+                os.fsync(local_file)
+                return 
+        except urllib2.HTTPError, e:
+            print "HTTP Error:", e.code, url
+            sys.exit(1)
+        except urllib2.URLError, e:
+            print "URL Error:", e.reason, url
+            sys.exit(1)
+
+
+def main(args):    
+    handle = FritzAccess(
+        address=args.ip,
+        port=args.port,
+        user=args.username,
+        password=args.password
+    )
+    handle.download_recent_calls(args.directory)
+    handle.download_phone_book(args.directory)
+    sys.exit(0)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='command line utility for FRITZ!Box access to download phone books and recent calls')
+    parser.add_argument('-d', '--directory', nargs='?', default='data', help='output directory')
+    parser.add_argument('-p', '--password', nargs='?', default='', help='password')
+    parser.add_argument('-u', '--username', nargs='?', default='', help='username')
+    parser.add_argument('-P', '--port', nargs='?', default=49000, help='tr064 port')
+    parser.add_argument('-i', '--ip', nargs='?', default="192.168.178.1", help='ip')
+    args = parser.parse_args()
+
+    main(args)

--- a/fritz_access.py
+++ b/fritz_access.py
@@ -12,28 +12,28 @@ class FritzAccess(object):
     def download_recent_calls(self, directory):
         result = self.fc.call_action("X_AVM-DE_OnTel", "GetCallList")
         filename = os.path.join(directory, "calls.xml")
-        self.download_file(result["NewCallListURL"], filename)
+        self.forward_file(result["NewCallListURL"], filename)
 
     def download_phone_book(self, directory):
         result = self.fc.call_action("X_AVM-DE_OnTel", "GetPhonebookList")
         for phonebook_id in result["NewPhonebookList"]:
             result_phonebook = self.fc.call_action("X_AVM-DE_OnTel", "GetPhonebook", NewPhonebookID=phonebook_id)
             filename = os.path.join(directory, "pbook_%s.xml" % phonebook_id)
-            print filename
-            self.download_file(result_phonebook["NewPhonebookURL"], filename)
+            self.forward_file(result_phonebook["NewPhonebookURL"], filename)
 
-    def download_file(self, url, filename):
+    def forward_file(self, url, filename):
         try:
             f = urllib2.urlopen(url)
-            with open(filename, "wb") as local_file:
-                local_file.write(f.read())
-                os.fsync(local_file)
-                return 
+            content = f.read()
+            # replace newline with space, it will be our separator
+            content = content.replace("\n", " ")
+            print filename
+            print content
         except urllib2.HTTPError, e:
-            print "HTTP Error:", e.code, url
+            print "Error (HTTP)", e.code, url
             sys.exit(1)
         except urllib2.URLError, e:
-            print "URL Error:", e.reason, url
+            print "Error (URL)", e.reason, url
             sys.exit(1)
 
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -6,7 +6,6 @@ const vcard = require("vcard-json");
 const phoneFormatter = require("phone-formatter");
 const xml2js = require("xml2js");
 const moment = require('moment');
-const fs = require('fs');
 const exec = require('child_process').exec;
 
 const CALL_TYPE = Object.freeze({

--- a/node_helper.js
+++ b/node_helper.js
@@ -4,12 +4,10 @@ const NodeHelper = require("node_helper");
 const CallMonitor = require("node-fritzbox-callmonitor");
 const vcard = require("vcard-json");
 const phoneFormatter = require("phone-formatter");
-const tr = require("tr-064");
 const xml2js = require("xml2js");
-const https = require("https");
-const url = require('url');
 const moment = require('moment');
-
+const fs = require('fs');
+const exec = require('child_process').exec;
 
 const CALL_TYPE = Object.freeze({
 	INCOMING : 1,
@@ -58,7 +56,7 @@ module.exports = NodeHelper.create({
 				this.setupMonitor();
 				if (this.config.password !== "")
 				{
-					this.setupApiAccess();
+					this.loadDataFromAPI();
 				}
 			};
 		}
@@ -93,61 +91,37 @@ module.exports = NodeHelper.create({
 	},
 
 	parseVcardFile: function() {
-        var self = this;
+		var self = this;
 
-		if (!self.config.vCard) {
+		if (!this.config.vCard) {
 			return;
 		}
 		vcard.parseVcardFile(self.config.vCard, function(err, data) {
 			//In case there is an error reading the vcard file
-			if (err) console.log("[" + self.name + "] " + err);
-			//success
-			else {
-				//For each contact in vcf file
-				for (var i = 0; i < data.length; i++) {
-					//For each phone number in contact
-					for (var a = 0; a < data[i].phone.length; a++) {
-						//normalize and add to AddressBook
-						self.AddressBook[self.normalizePhoneNumber(data[i].phone[a].value)] = data[i].fullname;
-					}
+			if (err) {
+				self.sendSocketNotification("contacts_loaded", -1);
+				console.log("[" + self.name + "] " + err);
+				return
+			}
+
+			//For each contact in vcf file
+			for (var i = 0; i < data.length; i++) {
+				//For each phone number in contact
+				for (var a = 0; a < data[i].phone.length; a++) {
+					//normalize and add to AddressBook
+					self.AddressBook[self.normalizePhoneNumber(data[i].phone[a].value)] = data[i].fullname;
 				}
 			}
+			self.sendSocketNotification("contacts_loaded", data.length);
 		});
 	},
 
-	insecureBoxRequest(self, targetUrl, callback) {
-		// WARNING: use this method ONLY for requests to your fritz.box
-		// it ignores self-signed certificates
-		// the fritz.box uses this kind of generated certificate
-		var parsedUrl = url.parse(targetUrl);
-		var options = { 
-			protocol: parsedUrl.protocol,
-			host: parsedUrl.hostname,
-			port: parsedUrl.port,
-			path: parsedUrl.path,
-			rejectUnauthorized: false,
-			requestCert: true,
-			agent: false
-		};
-		return https.get(options, function(response) {
-			if (response.statusCode !== 200)
-			{
-				console.error("Error code " + response.statusCode + " on request: " + targetUrl);
-			}
-			// Continuously update stream with data
-			var body = '';
-			response.on('data', function(d) {
-				body += d;
-			});
-			response.on('end', function() {
-				callback(self, body);
-			});
-		});
-	},
+	loadCallList: function(body) {
+		var self = this;
 
-	loadCallList: function(self, body) {
 		xml2js.parseString(body, function (err, result) {
 			if (err) {
+				self.sendSocketNotification("contacts_loaded", -1);
 				console.error(self.name + " error while parsing call list: " + err);
 				return;
 			}
@@ -170,9 +144,12 @@ module.exports = NodeHelper.create({
 		});
 	},
 
-	loadPhonebook: function(self, body) {
+	loadPhonebook: function(body) {
+		var self = this;
+
 		xml2js.parseString(body, function (err, result) {
 			if (err) {
+				self.sendSocketNotification("contacts_loaded", -1);
 				console.error(self.name + " error while parsing phonebook: " + err);
 				return;
 			}
@@ -188,63 +165,59 @@ module.exports = NodeHelper.create({
 				for (var index in contactNumbers)
 				{
 					var currentNumber = self.normalizePhoneNumber(contactNumbers[index]._);
-					self.AddressBook[currentNumber] = contactName;
+					self.AddressBook[currentNumber] = contactName[0];
 				}
 			}
+			self.sendSocketNotification("contacts_loaded", contactsArray.length);
 		});
 	},
 
-	setupApiAccess: function() {
+	loadDataFromAPI: function() {
+		const PARENT_DIR = 'modules/MMM-FRITZ-Box-Callmonitor/';
+
 		var self = this;
 
-		var tr064Api = new tr.TR064();
-		tr064Api.initTR064Device(self.config.fritzIP, self.config.tr064Port, function (err, device) {
-			if (err) {
-				console.error(self.name + " error: " + err);
-				return;
+		var options = ['fritz_access.py', '-d', 'data']
+		if (self.config.password !== "")
+		{
+			options.push('-p');
+			options.push(self.config.password);
+		}
+		if (self.config.username !== "")
+		{
+			options.push('-u');
+			options.push(self.config.username);
+		}
+		exec("python " + options.join(" "), {cwd: PARENT_DIR}, function (error, stdout, stderr) {
+			if (error) {
+				self.sendSocketNotification("contacts_loaded", -1);
+				console.error(self.name + " error while accessing FRITZ!Box: " + stderr);
+				throw error;
 			}
-			device.startEncryptedCommunication(function (err, sslDev) {
-				if (err) {
-					console.error(self.name + " error: " + err);
-					return;
-				}
-				if (self.config.username)
+			var phonebooks = stdout.split("\n");
+			for (var i = 0; i < phonebooks.length; i++)
+			{
+				if (phonebooks[i] === "")
 				{
-					sslDev.login(self.config.username, self.config.password);
+					continue;
 				}
-				else
+				var filename = process.cwd() + "/" + PARENT_DIR + phonebooks[i];
+				fs.readFile(filename, function(err, data) {
+					if (err) {
+						console.error(self.name + " error while reading phonebook: " + err);
+						self.sendSocketNotification("contacts_loaded", -1);
+					}
+					self.loadPhonebook(data);
+				});
+			}
+			filename = process.cwd() + "/" + PARENT_DIR + "data/calls.xml";
+			fs.readFile(filename, function(err, data) {
+				if (err)
 				{
-					sslDev.login(self.config.password);
+					console.error(self.name + " error while reading call list: " + err);
+					self.sendSocketNotification("contacts_loaded", -1);
 				}
-				var phoneservice = sslDev.services["urn:dslforum-org:service:X_AVM-DE_OnTel:1"];
-				phoneservice.actions.GetCallList(function (err, result) {
-					if (err) {
-						console.error(self.name + " error: " + err);
-						return;
-					}
-					self.insecureBoxRequest(self, result["NewCallListURL"], self.loadCallList);
-				});
-				phoneservice.actions.GetPhonebookList(function (err, result) {
-					if (err) {
-						console.error(self.name + " error: " + err);
-						return;
-					}
-					var phonebooks = result["NewPhonebookList"];
-
-					for (var phonebookID in phonebooks.split(",")) {
-						var filter = self.config.loadSpecificPhonebook;
-						if (filter == "" || filter == phonebookID)
-						{
-							phoneservice.actions.GetPhonebook({'NewPhonebookID' : phonebookID}, function (err, result) {
-								if (err) {
-									console.error(self.name + " error: " + err);
-									return;
-								}
-								self.insecureBoxRequest(self, result["NewPhonebookURL"], self.loadPhonebook);
-							});
-						}
-					}
-				});
+				self.loadCallList(data);
 			});
 		});
 	}

--- a/node_helper.js
+++ b/node_helper.js
@@ -191,34 +191,25 @@ module.exports = NodeHelper.create({
 		exec("python " + options.join(" "), {cwd: PARENT_DIR}, function (error, stdout, stderr) {
 			if (error) {
 				self.sendSocketNotification("contacts_loaded", -1);
-				console.error(self.name + " error while accessing FRITZ!Box: " + stderr);
+				console.error(self.name + " error while accessing FRITZ!Box: " + stderr + "\n" + stdout);
 				throw error;
 			}
-			var phonebooks = stdout.split("\n");
-			for (var i = 0; i < phonebooks.length; i++)
+			var files = stdout.split("\n");
+			console.log(files.length);
+			for (var i = 0; i + 1 < files.length; i += 2)
 			{
-				if (phonebooks[i] === "")
+				var filename = files[i];
+				var content = files[i + 1];
+
+				if (filename.indexOf("calls") !== -1)
 				{
-					continue;
+					// call list file
+					self.loadCallList(content);
+				} else {
+					// phone book file
+					self.loadPhonebook(content);
 				}
-				var filename = process.cwd() + "/" + PARENT_DIR + phonebooks[i];
-				fs.readFile(filename, function(err, data) {
-					if (err) {
-						console.error(self.name + " error while reading phonebook: " + err);
-						self.sendSocketNotification("contacts_loaded", -1);
-					}
-					self.loadPhonebook(data);
-				});
 			}
-			filename = process.cwd() + "/" + PARENT_DIR + "data/calls.xml";
-			fs.readFile(filename, function(err, data) {
-				if (err)
-				{
-					console.error(self.name + " error while reading call list: " + err);
-					self.sendSocketNotification("contacts_loaded", -1);
-				}
-				self.loadCallList(data);
-			});
 		});
 	}
 });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "node-fritzbox-callmonitor": "latest",
     "vcard-json": "latest",
     "phone-formatter": "latest",
-    "xml2js": "latest",
-    "tr-064": "latest"
+    "xml2js": "latest"
     }
 }


### PR DESCRIPTION
Unfortuantely the python library can not be installed through the existing `npm install` instead I added another optional installation step for this.

Changes for #17 :
- a small python script connects to the FRITZ!Box and downloads the `.xml` files for call list and phone book
- the python library does not get stuck after a certain number of uses, therefore: problem fixed
- the `node_helper` then reads and parses those `.xml` files

Other Changes:
- New calls are appended to the front of the list (i.e. they are shown first instead of last).
If this is #unwanted I can remove it, but it made more sense to me, to show new calls first (last calls fade out).
- Optional small status indicator (only shown, when no calls are present) shows how many contacts were loaded, and a small warning sign if anything went wrong. The config option is `showContactsStatus` (default: false).

