### PR TITLE
Overall improvements to API access

### DIFF
--- a/MMM-FRITZ-Box-Callmonitor.css
+++ b/MMM-FRITZ-Box-Callmonitor.css
@@ -1,0 +1,3 @@
+.time {
+  padding-left: 20px;
+}

--- a/MMM-FRITZ-Box-Callmonitor.js
+++ b/MMM-FRITZ-Box-Callmonitor.js
@@ -21,6 +21,7 @@ Module.register("MMM-FRITZ-Box-Callmonitor", {
 		maximumCallDistance: 60,
 		maximumCalls: 5,
 		fade: true,
+		debug: false,
 		fadePoint: 0.25,
 		username: "",
 		password: "",

--- a/MMM-FRITZ-Box-Callmonitor.js
+++ b/MMM-FRITZ-Box-Callmonitor.js
@@ -161,7 +161,6 @@ Module.register("MMM-FRITZ-Box-Callmonitor", {
 		//For each call in callHistory
 		for (var i = 0; i < history.length; i++) {
 			//Check if call is older than maximumCallDistance
-			console.log(moment(history[i].time));
 			if (moment(moment()).diff(moment(history[i].time)) > this.config.maximumCallDistance * 60000) {
 				//is older -> remove from list
 				history.splice(i, 1);

--- a/MMM-FRITZ-Box-Callmonitor.js
+++ b/MMM-FRITZ-Box-Callmonitor.js
@@ -22,6 +22,7 @@ Module.register("MMM-FRITZ-Box-Callmonitor", {
 		fadePoint: 0.25,
 		username: "",
 		password: "",
+		reloadContactsInterval: 30, // 30 minutes, set to 0 to disable
 		showContactsStatus: false
 	},
 
@@ -55,9 +56,18 @@ Module.register("MMM-FRITZ-Box-Callmonitor", {
 		this.contactsLoaded = false;
 		this.numberOfContacts = 0;
 		this.contactLoadError = false;
+		this.errorCode = "";
 
 		//Send config to the node helper
 		this.sendSocketNotification("CONFIG", this.config);
+
+		//set up the contact reloading
+		if (this.config.password !== "" && this.config.reloadContactsInterval !== 0) {
+			setInterval(function() {
+				self.sendSocketNotification("RELOAD_CONTACTS");
+			}, this.config.reloadContactsInterval * 60000);
+		}
+
 		Log.info("Starting module: " + this.name);
 	},
 
@@ -89,12 +99,17 @@ Module.register("MMM-FRITZ-Box-Callmonitor", {
 			//Send notification for currentCall module
 			this.sendNotification("CALL_DISCONNECTED", payload.caller);
 
-			//Add call to callHistory (timestamp and caller) or if minimumCallLength is set only missed calls
-			if (payload.duration <= this.config.minimumCallLength) {
-				this.callHistory.unshift({"time": moment(), "caller": payload.caller});
+			if (this.config.password !== "") {
+				// if we have an API connection, check if the calls was really missed
+				this.sendSocketNotification("RELOAD_CALLS");
+			} else {
+				//Add call to callHistory (timestamp and caller) or if minimumCallLength is set only missed calls
+				if (payload.duration <= this.config.minimumCallLength) {
+					this.callHistory.unshift({"time": moment(), "caller": payload.caller});
+				}
+				//Update call list on UI
+				this.updateDom(3000);
 			}
-			//Update call list on UI
-			this.updateDom(3000);
 
 			//Remove alert only on disconnect if it is the current alert shown
 			if (this.activeAlert === payload.caller) {
@@ -104,37 +119,65 @@ Module.register("MMM-FRITZ-Box-Callmonitor", {
 			}
 		}
 		if (notification === "call_history") {
-			//Add call to callHistory (timestamp and caller) or if minimumCallLength is set only missed calls
-			this.callHistory = this.callHistory.concat(payload);
-			if (payload.length > 0)
-			{
-				this.updateDom(3000);
+			//update call history from API
+			this.callHistory = payload;
+			this.sortHistory();
+			this.trimHistory();
+
+			this.updateDom(3000);
+		}
+		if (notification === "error") {
+			this.contactsLoaded = true;
+			this.contactLoadError = true;
+			this.errorCode = payload;
+
+			if (this.config.showContactsStatus) {
+				this.updateDom();
 			}
 		}
 		if (notification === "contacts_loaded") {
 			this.contactsLoaded = true;
-			if (payload === -1) {
-				this.contactLoadError = true;
+			this.numberOfContacts = payload;
+
+			if (this.config.showContactsStatus) {
 				this.updateDom();
-				return;
 			}
-			this.numberOfContacts += payload;
-			this.updateDom();
 		}
 	},
 
-	getDom: function() {
+	sortHistory: function() {
+		var history = this.callHistory;
+
+		//Sort history by time
+		history.sort(function(a, b) {
+			return moment(moment(a.time)).diff(moment(b.time)) < 0;
+		});
+
+		this.callHistory = history;
+	},
+
+	trimHistory: function() {
+		var history = this.callHistory;
+
 		//For each call in callHistory
-		for (var i = 0; i < this.callHistory.length; i++) {
+		for (var i = 0; i < history.length; i++) {
 			//Check if call is older than maximumCallDistance
-			if (moment(moment()).diff(moment(this.callHistory[i].time)) > this.config.maximumCallDistance * 60000) {
+			if (moment(moment()).diff(moment(history[i].time)) > this.config.maximumCallDistance * 60000) {
 				//is older -> remove from list
-				this.callHistory.splice(i, 1);
+				history.splice(i, i + 1);
 				i--;
 			}
 		}
-		//get latest x calls configured by maximumCalls
-		var calls = this.callHistory.slice(this.callHistory.length - this.config.maximumCalls, this.callHistory.length);
+
+		this.callHistory = history;
+	},
+
+	getDom: function() {
+		//remove old calls
+		this.trimHistory();
+
+		//get maximum number of calls from call history
+		var calls = this.callHistory.slice(0, this.config.maximumCalls);
 
 		//Create table
 		var wrapper = document.createElement("table");
@@ -158,7 +201,8 @@ Module.register("MMM-FRITZ-Box-Callmonitor", {
 				}
 				if (this.contactLoadError)
 				{
-					content += " <span class='small fa fa-exclamation-triangle'/></span>";
+					content += " <span class='small fa fa-exclamation-triangle'/></span> ";
+					content += this.translate(this.errorCode);
 				}
 				content += ")";
 			}

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ modules: [
 
 There are currently two different ways to get this module to displays the name of the caller, rather than the number.
 
-1. Load a .vcf file, for example exported contacts from your phone (see `vCard` option)
-2. Access your FRITZ!Box contacts via the TR-064 API (see `password` and `username` option)
+1. Load a .vcf file, for example exported contacts from your phone (see options marked with **VCF**)
+2. Access your FRITZ!Box contacts via the TR-064 API (see options marked with **API**)
 
 The latter will also load recently missed calls, which happened before you started your mirror.
 
@@ -41,18 +41,19 @@ If you are interested in having a list with all active calls as well, check out 
 
 The following properties can be configured:
 
-
 <table width="100%">
 	<!-- why, markdown... -->
 	<thead>
 		<tr>
 			<th>Option</th>
+			<th>Method</th>
 			<th width="100%">Description</th>
 		</tr>
 	<thead>
 	<tbody>
 		<tr>
 			<td><code>numberFontSize</code></td>
+			<td>any</td>
 			<td>Font size of the phone number displayed in the alert.<br>
 				<br><b>Possible values:</b> any <code>int</code> or <code>float</code>
 				<br><b>Default value:</b> <code>30</code>
@@ -60,6 +61,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>vCard</code></td>
+			<td>VCF</td>
 			<td>Absolute path to a .vcf file for number to name conversion.<br>
 				<br><b>Possible values:</b> <code>string</code>
 				<br><b>Default value:</b> <code>false</code>
@@ -67,6 +69,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>password</code></td>
+			<td>API</td>
 			<td>Password to access the FritzBox API. (<b>optional</b>) <br> 
 			If you enter this, it directly loads your phonebook(s) and recently missed calls from the FritzBox.<br>
 			If you have specified a username for your access to the FritzBox, see below. <br>
@@ -77,6 +80,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>username</code></td>
+			<td>API</td>
 			<td>Username to access the FritzBox API. (<b>optional</b>)<br>
 			Specify the username if you have one set up for the FritzBox access (see password option). <br>
 			Leave out if you have no username (default).<br>
@@ -85,7 +89,18 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
+			<td><code>reloadContactsInterval</code></td>
+			<td>API</td>
+			<td>How often contacts are reloaded from the FRITZ!Box.<br>
+			Set to 0 to disable reloading contacts, they are only loaded once after the start of the mirror.
+			<br>
+				<br><b>Possible values:</b> <code>time</code> in <code>minutes</code>
+				<br><b>Default value:</b> <code>30</code>
+			</td>
+		</tr>
+		<tr>
 			<td><code>showContactsStatus</code></td>
+			<td>any</td>
 			<td>If no recent calls are displayed, a small symbol shows how many contacts are loaded in your phonebook. <br>
 			A small warning sign appears if any error occurs when importing contacts from vCard or the FRITZ!Box.
 			<br>
@@ -95,13 +110,15 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>minimumCallLength</code></td>
-			<td>There is no real way to tell whether a call was missed or not because voice mails count as connected calls. You can however change the time a call has to be for it to be considered not missed. You should probably use a value as long as your voice mail. <br>Default <code>0</code> means any call gets added to the history.<br>
+			<td>VCF</td>
+			<td>There is no real way to tell whether a call was missed or not because voice mails count as connected calls. You can however change the time a call has to be for it to be considered not missed. You should probably use a value as long as your voice mail. Note: this is not needed if you are using the API access. <br>Default <code>0</code> means any call gets added to the history.<br>
 				<br><b>Possible values:</b> <code>time</code> in <code>seconds</code>
 				<br><b>Default value:</b> <code>0</code>
 			</td>
 		</tr>
 		<tr>
 			<td><code>maximumCallDistance</code></td>
+			<td>any</td>
 			<td>Time after which calls get removed from the list.<br>
 				<br><b>Possible values:</b> <code>time</code> in <code>min</code>
 				<br><b>Default value:</b> <code>60</code>
@@ -109,6 +126,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>maximumCalls</code></td>
+			<td>any</td>
 			<td>Maximum number of calls to be shown in the list.<br>
 				<br><b>Possible values:</b> any <code>int</code>
 				<br><b>Default value:</b> <code>5</code>
@@ -116,6 +134,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>fritzIP</code></td>
+			<td>any</td>
 			<td>IP Adress of your FRITZ!Box.<br>
 				<br><b>Possible values:</b> IP Address
 				<br><b>Default value:</b> <code>192.168.178.1</code>
@@ -123,6 +142,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>fritzPort</code></td>
+			<td>any</td>
 			<td>Port of your FRITZ!Box callmonitor (you should not have to change that)<br>
 				<br><b>Possible values:</b> any <code>int</code>
 				<br><b>Default value:</b> <code>1012</code>
@@ -130,6 +150,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>fade</code></td>
+			<td>any</td>
 			<td>Fade old calls to black. (Gradient)<br>
 				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
 				<br><b>Default value:</b> <code>true</code>
@@ -137,6 +158,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>fadePoint</code></td>
+			<td>any</td>
 			<td>Where to start fade?<br>
 				<br><b>Possible values:</b> <code>0</code> (top of the list) - <code>1</code> (bottom of list)
 				<br><b>Default value:</b> <code>0.25</code>

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
+			<td><code>minimumCallLength</code></td>
+			<td>VCF</td>
+			<td>There is no real way to tell whether a call was missed or not because voice mails count as connected calls. You can however change the time a call has to be for it to be considered not missed. You should probably use a value as long as your voice mail. Note: this is not needed if you are using the API access. <br>Default <code>0</code> means any call gets added to the history.<br>
+				<br><b>Possible values:</b> <code>time</code> in <code>seconds</code>
+				<br><b>Default value:</b> <code>0</code>
+			</td>
+		</tr>
+		<tr>
 			<td><code>password</code></td>
 			<td>API</td>
 			<td>Password to access the FritzBox API. (<b>optional</b>) <br> 
@@ -106,14 +114,6 @@ The following properties can be configured:
 			<br>
 				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
 				<br><b>Default value:</b> <code>false</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>minimumCallLength</code></td>
-			<td>VCF</td>
-			<td>There is no real way to tell whether a call was missed or not because voice mails count as connected calls. You can however change the time a call has to be for it to be considered not missed. You should probably use a value as long as your voice mail. Note: this is not needed if you are using the API access. <br>Default <code>0</code> means any call gets added to the history.<br>
-				<br><b>Possible values:</b> <code>time</code> in <code>seconds</code>
-				<br><b>Default value:</b> <code>0</code>
 			</td>
 		</tr>
 		<tr>

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ The following properties can be configured:
 				<br><b>Default value:</b> <code>0.25</code>
 			</td>
 		</tr>
+		<tr>
+			<td><code>debug</code></td>
+			<td>any</td>
+			<td>Should debug information be displayed in case of errors?<br>
+				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
+				<br><b>Default value:</b> <code>false</code>
+			</td>
+		</tr>
 	</tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ modules: [
 ### Loading your contacts
 
 There are currently two different ways to get this module to displays the name of the caller, rather than the number.
+They are both optional, and you can combine them.
 
-1. Load a .vcf file, for example exported contacts from your phone (see options marked with **VCF**)
-2. Access your FRITZ!Box contacts via the TR-064 API (see options marked with **API**)
+1. Load a .vcf file, for example exported contacts from your phone (see [options](#configuration-options) marked with **VCF**)
+2. Access your FRITZ!Box contacts via the TR-064 API (see [options](#configuration-options) marked with **API**)
 
 The latter will also load recently missed calls, which happened before you started your mirror.
 
@@ -69,8 +70,8 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>minimumCallLength</code></td>
-			<td>VCF</td>
-			<td>There is no real way to tell whether a call was missed or not because voice mails count as connected calls. You can however change the time a call has to be for it to be considered not missed. You should probably use a value as long as your voice mail. Note: this is not needed if you are using the API access. <br>Default <code>0</code> means any call gets added to the history.<br>
+			<td>any</td>
+			<td>There is no real way to tell whether a call was missed or not because voice mails count as connected calls. You can however change the time a call has to be for it to be considered not missed. You should probably use a value as long as your voice mail. <br>Default <code>0</code> means any call gets added to the history.<br> If you enter a time larger than `0`, any call that is longer than that time, is not added to the list.<br>
 				<br><b>Possible values:</b> <code>time</code> in <code>seconds</code>
 				<br><b>Default value:</b> <code>0</code>
 			</td>
@@ -104,6 +105,15 @@ The following properties can be configured:
 			<br>
 				<br><b>Possible values:</b> <code>time</code> in <code>minutes</code>
 				<br><b>Default value:</b> <code>30</code>
+			</td>
+		</tr>
+		<tr>
+			<td><code>showAllCalls</code></td>
+			<td>API</td>
+			<td>Show all calls (`true`) or only missed calls (`false`)?
+			<br>
+				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
+				<br><b>Default value:</b> <code>true</code>
 			</td>
 		</tr>
 		<tr>

--- a/README.md
+++ b/README.md
@@ -108,12 +108,13 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
-			<td><code>showAllCalls</code></td>
+			<td><code>deviceFilter</code></td>
 			<td>API</td>
-			<td>Show all calls (`true`) or only missed calls (`false`)?
+			<td> You can enter the names of your real phone devices here (<b>optional</b>). You should be redirected to the list after you login <a href="http://fritz.box/?lp=dectDev">here</a>. <br>
+			Example: <code>deviceFilter: ["firstphone", "secondphone"]</code>.
 			<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>true</code>
+				<br><b>Possible values:</b> <code>array</code> of <code>strings</code>
+				<br><b>Default value:</b> <code>[]</code>
 			</td>
 		</tr>
 		<tr>
@@ -178,9 +179,11 @@ The following properties can be configured:
 </table>
 
 ## Dependencies
+
 - [node-fritzbox-callmonitor](https://www.npmjs.com/package/node-fritzbox-callmonitor) (installed by `npm install`)
-- [vcard-json](https://www.npmjs.com/package/vcard-json) (installed by `npm install`)
 - [phone-formatter](https://www.npmjs.com/package/phone-formatter) (installed by `npm install`)
+- [python-shell](https://www.npmjs.com/package/python-shell) (installed by `npm install`)
+- [vcard-json](https://www.npmjs.com/package/vcard-json) (installed by `npm install`)
 - [xml2js](https://www.npmjs.com/package/xml2js): (installed by `npm install`)
 - [fritzconnection](https://pypi.python.org/pypi/fritzconnection): (installed by `sudo apt-get install python-dev libxml2-dev libxslt1-dev zlib1g-dev && sudo pip install fritzconnection`)
 

--- a/fritz_access.py
+++ b/fritz_access.py
@@ -44,8 +44,17 @@ def main(args):
         user=args.username,
         password=args.password
     )
-    handle.download_recent_calls(args.directory)
+    
+    if args.contacts_only:
+        handle.download_phone_book(args.directory)
+        return
+    
+    if args.calls_only:
+        handle.download_recent_calls(args.directory)
+        return
+    
     handle.download_phone_book(args.directory)
+    handle.download_recent_calls(args.directory)
     sys.exit(0)
 
 if __name__ == "__main__":
@@ -55,6 +64,8 @@ if __name__ == "__main__":
     parser.add_argument('-u', '--username', nargs='?', default='', help='username')
     parser.add_argument('-P', '--port', nargs='?', default=49000, help='tr064 port')
     parser.add_argument('-i', '--ip', nargs='?', default="192.168.178.1", help='ip')
+    parser.add_argument('-co', '--contacts-only', action='store_true', help='only return contacts')
+    parser.add_argument('-ca', '--calls-only', action='store_true', help='only return calls')
     args = parser.parse_args()
 
     main(args)

--- a/node_helper.js
+++ b/node_helper.js
@@ -140,7 +140,6 @@ module.exports = NodeHelper.create({
 				if (type == CALL_TYPE.MISSED || type == CALL_TYPE.INCOMING)
 				{
 					if (type == CALL_TYPE.INCOMING && self.config.deviceFilter && self.config.deviceFilter.indexOf(call.Device[0]) > -1) {
-						console.log("Filtered " + call.Name[0] + " " + call.Date[0]);
 						continue;
 					}
 					var callInfo = {"time": moment(call.Date[0], "DD.MM.YY HH:mm"), "caller": self.getName(call.Caller[0])};

--- a/node_helper.js
+++ b/node_helper.js
@@ -108,7 +108,9 @@ module.exports = NodeHelper.create({
 			//In case there is an error reading the vcard file
 			if (err) {
 				self.sendSocketNotification("error", "vcf_parse_error");
-				console.log("[" + self.name + "] " + err);
+				if (self.config.debug) {
+					console.log("[" + self.name + "] error while parsing vCard " + err);
+				}
 				return
 			}
 
@@ -163,7 +165,9 @@ module.exports = NodeHelper.create({
 		xml2js.parseString(body, function (err, result) {
 			if (err) {
 				self.sendSocketNotification("error", "phonebook_parse_error");
-				console.error(self.name + " error while parsing phonebook: " + err);
+				if (self.config.debug) {
+					console.error(self.name + " error while parsing phonebook: " + err);
+				}
 				return;
 			}
 			var contactsArray = result.phonebooks.phonebook[0].contact;

--- a/node_helper.js
+++ b/node_helper.js
@@ -104,7 +104,7 @@ module.exports = NodeHelper.create({
 		vcard.parseVcardFile(self.config.vCard, function(err, data) {
 			//In case there is an error reading the vcard file
 			if (err) {
-				self.sendSocketNotification("contacts_loaded", -1);
+				self.sendSocketNotification("error", "vcf_parse_error");
 				console.log("[" + self.name + "] " + err);
 				return
 			}

--- a/node_helper.js
+++ b/node_helper.js
@@ -9,9 +9,9 @@ const moment = require('moment');
 const exec = require('child_process').exec;
 
 const CALL_TYPE = Object.freeze({
-	INCOMING : 1,
-	MISSED : 2,
-	OUTGOING : 3
+	INCOMING : "1",
+	MISSED : "2",
+	OUTGOING : "3"
 })
 // outgoing missed calls are not in the list
 
@@ -132,12 +132,18 @@ module.exports = NodeHelper.create({
 			}
 			var callArray = result.root.Call;
 			var callHistory = []
+
 			for (var index in callArray)
 			{
 				var call = callArray[index];
-				if (call.Type == CALL_TYPE.MISSED)
+				var type = call.Type[0];
+				if (type == CALL_TYPE.MISSED || type == CALL_TYPE.INCOMING)
 				{
-					var callInfo = {"time": moment(call.Date[0], "DD-MM-YY HH:mm"), "caller": self.getName(call.Caller[0])};
+					if (type == CALL_TYPE.INCOMING && self.config.deviceFilter && self.config.deviceFilter.indexOf(call.Device[0]) > -1) {
+						console.log("Filtered " + call.Name[0] + " " + call.Date[0]);
+						continue;
+					}
+					var callInfo = {"time": moment(call.Date[0], "DD.MM.YY HH:mm"), "caller": self.getName(call.Caller[0])};
 					if (call.Name[0])
 					{
 						callInfo.caller = call.Name[0];

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node-fritzbox-callmonitor": "latest",
     "vcard-json": "latest",
     "phone-formatter": "latest",
+    "python-shell": "latest",
     "xml2js": "latest"
     }
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -1,4 +1,11 @@
 {
   "title": "Eingehender Anruf",
-  "noCall": "Keine kürzlichen Anrufe."
+  "noCall": "Keine kürzlichen Anrufe.",  
+
+  // keep the error messages short
+  "calllist_parse_error": "Anrufliste unlesbar.",
+  "phonebook_parse_error": "Telefonbuch unlesbar.",
+  "login_error": "Logindaten falsch?",
+  "network_error": "FRITZ!Box nicht erreichbar.",
+  "unknown_error": "Unbekannter Fehler."
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -5,6 +5,7 @@
   // keep the error messages short
   "calllist_parse_error": "Anrufliste unlesbar.",
   "phonebook_parse_error": "Telefonbuch unlesbar.",
+  "vcf_parse_error": "vCard unlesbar.",
   "login_error": "Logindaten falsch?",
   "network_error": "FRITZ!Box nicht erreichbar.",
   "unknown_error": "Unbekannter Fehler."

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,4 +1,11 @@
 {
   "title": "Incoming Call",
-  "noCall": "No recent calls."
+  "noCall": "No recent calls.",
+
+  // keep the error messages short
+  "calllist_parse_error": "Can't parse calllist.",
+  "phonebook_parse_error": "Can't parse phonebook.",
+  "login_error": "Login data wrong?",
+  "network_error": "Could not reach FRITZ!Box.",
+  "unknown_error": "Unknown error."
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -5,6 +5,7 @@
   // keep the error messages short
   "calllist_parse_error": "Can't parse calllist.",
   "phonebook_parse_error": "Can't parse phonebook.",
+  "vcf_parse_error": "Can't parse vCard.",
   "login_error": "Login data wrong?",
   "network_error": "Could not reach FRITZ!Box.",
   "unknown_error": "Unknown error."


### PR DESCRIPTION
Fixes #19.

Changes (finished and unfinished):

- [x] Reload contacts in specified interval
- [x] Filter calls connected to real devices (to distinguish between connected calls and voice mail)
- [x] Add small minimal padding margin between caller and time
- [x] Add error codes (if `showContactsStatus` is enabled)
- [x] Removed some debug prints (can be shown with `debug: true` in config)
- [x] Update README.md
- [ ] See if #20 can be debugged better with this (or is it maybe even fixed?)
- [ ] Someone else also should test the whole thing and verify it works (+ find possible unclear config options)
