### PR TITLE
Fixed 'TypeError: PythonShell is not a constructor'

### DIFF
--- a/fritz_access.py
+++ b/fritz_access.py
@@ -23,7 +23,7 @@ class FritzAccess(object):
         if (len(result) == 0):
             raise Exception("Please check if your user has access to \"View and edit FRITZ!Box settings\".")
             sys.exit(1)
-        for phonebook_id in result["NewPhonebookList"]:
+        for phonebook_id in result["NewPhonebookList"].replace(",", ""):
             result_phonebook = self.fc.call_action("X_AVM-DE_OnTel", "GetPhonebook", NewPhonebookID=phonebook_id)
             filename = os.path.join(directory, "pbook_%s.xml" % phonebook_id)
             self.forward_file(result_phonebook["NewPhonebookURL"], filename)

--- a/node_helper.js
+++ b/node_helper.js
@@ -7,7 +7,7 @@ const phoneFormatter = require("phone-formatter");
 const xml2js = require("xml2js");
 const moment = require('moment');
 const exec = require('child_process').exec;
-const PythonShell = require('python-shell');
+const {PythonShell} = require('python-shell');
 const path = require("path");
 
 const CALL_TYPE = Object.freeze({
@@ -196,7 +196,7 @@ module.exports = NodeHelper.create({
 			console.log('Starting access to FRITZ!Box...');
 		}
 
-		var args = ['-i', self.config.fritzIP, '-p', self.config.password];
+		let args = ['-i', self.config.fritzIP, '-p', self.config.password];
 		if (self.config.username !== "")
 		{
 			args.push('-u');
@@ -207,13 +207,14 @@ module.exports = NodeHelper.create({
 			args.push(additionalOption);
 		}
 
-		var options = {
+		let options = {
+                        pythonPath: 'python',
 			mode: 'json',
 			scriptPath: path.resolve(__dirname),
 			args: args
 		};
 
-		var pyshell = new PythonShell('fritz_access.py', options);
+		let pyshell = new PythonShell('fritz_access.py', options);
 
 		pyshell.on('message', function (message) {
 			if (message.filename.indexOf("calls") !== -1)

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "phone-formatter": "latest",
     "python-shell": "latest",
     "xml2js": "latest"
-    }
+  }
 }


### PR DESCRIPTION
Fixed #32 by applying and testing solution found by @PieBa. Thanks for this! 

Root cause seems a breaking change in PythonShell API. After this fix the calls get correctly displayed again, the error log 'TypeError: PythonShell is not a constructor' disappears.